### PR TITLE
AN-4728 fork of react-tiff with updated styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tiff",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "keywords": [
     "tiff",
     "react-tiff",
@@ -11,12 +11,15 @@
   "description": "A React component for viewing TIFF images.",
   "author": "harundogdu",
   "license": "MIT",
-  "repository": "harundogdu/react-tiff",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.js",
   "engines": {
     "node": ">=10"
+  },
+  "repository": "https://github.com/Anatomy-Financial/react-tiff",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "build": "microbundle-crl --no-compress --format modern,cjs",

--- a/src/styles.module.css
+++ b/src/styles.module.css
@@ -8,7 +8,7 @@
   width: 100%;
   height: 100%;
   gap: 1rem;
-  padding: 2rem;
+  padding: 0.5rem;
   box-sizing: border-box;
   position: relative;
 }
@@ -34,10 +34,10 @@
 }
 
 canvas {
-  max-width: 1024px;
+  max-width: 100%;
   width: fit-content;
   height: 100%;
-  max-height: 700px;
+  max-height: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
I want to merge this pull request because it forks `react-tiff` for easy display of tiff images, with some updated CSS styles to work better for our use case, and give us more control over this codebase if we need to make further modifications.